### PR TITLE
Fix problem when object list points are updated

### DIFF
--- a/src/components/PureVueChart.vue
+++ b/src/components/PureVueChart.vue
@@ -222,7 +222,7 @@ export default {
   },
   watch: {
     points(updatedPoints) {
-      this.tween(updatedPoints);
+      this.tween(this.dataPoints);
     },
   },
   created() {


### PR DESCRIPTION
Currently, when you update the object list points, the chart will start to throw exceptions. The issue was that in the watch property, you call directly the new points and not to the computed property. 