### PR TITLE
Allow fully customizable labels

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,18 +73,69 @@
     <pure-vue-chart
       :show-y-axis="false"
       :show-x-axis="true"
+      :label-height="20"
       :points="dataPointObjects"
       :width="chartWidth"
       :height="chartHeight"
       :show-values="true"
     >
-      <template v-slot:label="barProps" >
-        <tspan v-if="barProps.bar.index === 1">Here</tspan>
-        <tspan v-else-if="barProps.bar.index === 2">are</tspan>
-        <tspan v-else-if="barProps.bar.index === 3">custom</tspan>
-        <tspan v-else-if="barProps.bar.index === 4">labels</tspan>
-        <tspan v-else-if="barProps.bar.index === 5">&#128526;</tspan>
-        <tspan v-else>{{ barProps.bar.index }}</tspan>
+      <template v-slot:label="barProps">
+        <text
+          v-if="barProps.bar.index === 1"
+          :x="barProps.bar.midPoint"
+          :y="`${barProps.bar.yLabel + 10}px`"
+          text-anchor="middle"
+        >
+          Here
+        </text>
+        <text
+          v-else-if="barProps.bar.index === 2"
+          :x="barProps.bar.midPoint"
+          :y="`${barProps.bar.yLabel + 10}px`"
+          text-anchor="middle"
+        >
+          are
+        </text>
+        <text
+          v-else-if="barProps.bar.index === 3"
+          :x="barProps.bar.midPoint"
+          :y="`${barProps.bar.yLabel + 10}px`"
+          text-anchor="middle"
+        >
+          custom
+        </text>
+        <text
+          v-else-if="barProps.bar.index === 4"
+          :x="barProps.bar.midPoint"
+          :y="`${barProps.bar.yLabel + 10}px`"
+          text-anchor="middle"
+        >
+          labels
+        </text>
+        <image
+          v-else-if="barProps.bar.index === 5"
+          :x="`${barProps.bar.midPoint - 10}px`"
+          :y="`${barProps.bar.yLabel}px`"
+          height="20"
+          width="20"
+          href="https://raw.githubusercontent.com/vuejs/art/master/logo.png"
+        />
+        <text
+          v-else-if="barProps.bar.index === 6"
+          :x="barProps.bar.midPoint"
+          :y="`${barProps.bar.yLabel + 10}px`"
+          text-anchor="middle"
+        >
+          &#128526;
+        </text>
+        <text
+          v-else
+          :x="barProps.bar.midPoint"
+          :y="`${barProps.bar.yLabel + 10}px`"
+          text-anchor="middle"
+        >
+          {{ barProps.bar.label }}
+        </text>
       </template>
     </pure-vue-chart>
   </div>

--- a/src/components/PureVueChart.vue
+++ b/src/components/PureVueChart.vue
@@ -36,13 +36,18 @@
             text-anchor="middle"
           >{{ bar.staticValue }}</text>
           <g v-if="showXAxis">
-            <text
-              :x="bar.midPoint"
-              :y="`${innerChartHeight + 14}px`"
-              text-anchor="middle"
+            <slot
+              name="label"
+              :bar="bar"
             >
-              <slot name='label' :bar="bar">{{ dataLabels[bar.index] }}</slot>
-            </text>
+              <text
+                :x="bar.midPoint"
+                :y="`${bar.yLabel + 10}px`"
+                text-anchor="middle"
+              >
+                {{ bar.label }}
+              </text>
+            </slot>
             <line
               :x1="bar.midPoint"
               :x2="bar.midPoint"
@@ -116,6 +121,7 @@ export default {
     width: { type: Number, default: 300 },
     showYAxis: { type: Boolean, default: false },
     showXAxis: { type: Boolean, default: false },
+    labelHeight: { type: Number, default: 12 },
     showTrendLine: { type: Boolean, default: false },
     trendLineColor: { type: String, default: 'green' },
     trendLineWidth: { type: Number, default: 2 },
@@ -167,8 +173,8 @@ export default {
     },
     xAxisHeight() {
       return this.showYAxis
-        ? 12
-        : 12 + this.extraBottomHeightForYAxisLabel + this.extraTopHeightForYAxisLabel;
+        ? this.labelHeight
+        : this.labelHeight + this.extraBottomHeightForYAxisLabel + this.extraTopHeightForYAxisLabel;
     },
     fullSvgWidth() {
       return this.width;
@@ -202,8 +208,10 @@ export default {
       return this.dynamicPoints.map((dynamicValue, index) => ({
         staticValue: this.staticPoints[index],
         index,
+        label: this.dataLabels[index],
         width: this.partitionWidth - 2,
         midPoint: this.partitionWidth / 2,
+        yLabel: this.innerChartHeight + 4,
         x: index * this.partitionWidth,
         xMidpoint: index * this.partitionWidth + this.partitionWidth / 2,
         yOffset: this.innerChartHeight - this.y(dynamicValue),


### PR DESCRIPTION
:warning: This is breaking change if you used custom labels previously but this is only way to allow to render also images for labels:
![image](https://user-images.githubusercontent.com/165205/71773691-08450000-2f6a-11ea-8dfb-db3e9ef83033.png)

* Adds `label-height` option to allow customizable label height in pixels
* Extends template binded `bar` properties with label Y position `yLabel` and label text `label`
